### PR TITLE
Pathname handling in get-node-id improved

### DIFF
--- a/uuid.lisp
+++ b/uuid.lisp
@@ -97,13 +97,11 @@ characters.~@:>" string (length string)))
 	 #+linux
 	  (let ((interface (first (remove "lo"
 					  (mapcan (lambda (x) (last (pathname-directory x)))
-						  (directory "/sys/class/net/*/"))
+						  (directory "/sys/class/net/*/address"))
 					  :test #'equal))))
 	    (when (not (null interface))
 	      (with-open-file (address (make-pathname :directory
-						      (concatenate 'string
-								   "/sys/class/net/"
-								   interface)
+                                                      `(:absolute "sys" "class" "net" ,interface)
 						      :name "address"))
 		(parse-integer (remove #\: (read-line address)) :radix 16))))
 


### PR DESCRIPTION
The call to `make-pathname :directory` with a namestring containing
/-chars signalled an error by LispWorks 6.1. This was replaced with
:absolute path specification.

Some linux's /sys/class/net entries (e.g. "power") did not have
"address" information. Namestring for `directory` call was appended
with "address", so that only sys-entries that have the address
information are considered.