### PR TITLE
Ironclad is a very heavyweight system so clasp provides uuid functions

### DIFF
--- a/uuid.asd
+++ b/uuid.asd
@@ -16,5 +16,5 @@
 
   :serial t ;; the dependencies are linear.
   :components ((:file "uuid"))
-  :depends-on ("ironclad" "trivial-utf-8"))
+  :depends-on (#-clasp "ironclad" "trivial-utf-8"))
 

--- a/uuid.lisp
+++ b/uuid.lisp
@@ -287,7 +287,14 @@ characters.~@:>" string (length string)))
 (defun digest-uuid (digest uuid name)
   "Helper function that produces a digest from a namespace (a byte array) and a string. Used for the
 generation of version 3 and 5 uuids."
-  (let ((digester (ironclad:make-digest digest)))
-    (ironclad:update-digest digester uuid)
-    (ironclad:update-digest digester (trivial-utf-8:string-to-utf-8-bytes name))
-    (ironclad:produce-digest digester)))
+  #+clasp(cond
+           ((eq digest :md5)
+            (core:digest-md5 (list uuid (trivial-utf-8:string-to-utf-8-bytes name))))
+           ((eq digest :sha1)
+            (core:digest-sha1 (list uuid (trivial-utf-8:string-to-utf-8-bytes name))))
+           (t (error "Add support for the digest ~a" digest)))
+  #-clasp(let ((digester (ironclad:make-digest digest)))
+           (ironclad:update-digest digester uuid)
+           (ironclad:update-digest digester (trivial-utf-8:string-to-utf-8-bytes name))
+           (ironclad:produce-digest digester))
+  )


### PR DESCRIPTION
Clasp provides its own md5 and sha1 functions - so it doesn't require ironclad - which takes at least 20 minutes to compile with clasps slow llvm based compiler.
Could you accept this PR so that clasp can use its own functions and remove the ironclad dependency.